### PR TITLE
chore: replace #pragma once with old-style include guards

### DIFF
--- a/core/include/balsa/eigen/slice_filter.hpp
+++ b/core/include/balsa/eigen/slice_filter.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#if !defined(BALSA_EIGEN_SLICE_FILTER_HPP)
+#define BALSA_EIGEN_SLICE_FILTER_HPP
 
 #include "balsa/eigen/types.hpp"
 
@@ -45,3 +46,4 @@ auto slice_filter_col(const Eigen::MatrixBase<Derived> &A, const VectorX<bool> &
 }
 
 }// namespace balsa::eigen
+#endif

--- a/core/include/balsa/eigen/stl2eigen.hpp
+++ b/core/include/balsa/eigen/stl2eigen.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#if !defined(BALSA_EIGEN_STL2EIGEN_HPP)
+#define BALSA_EIGEN_STL2EIGEN_HPP
 #include "balsa/eigen/types.hpp"
 #include "balsa/eigen/container_size.hpp"
 #include <ranges>
@@ -73,3 +74,4 @@ auto stl2eigen(const Container &vec) {
 }
 
 }// namespace balsa::eigen
+#endif

--- a/core/include/balsa/zipper/stl2zipper.hpp
+++ b/core/include/balsa/zipper/stl2zipper.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#if !defined(BALSA_ZIPPER_STL2ZIPPER_HPP)
+#define BALSA_ZIPPER_STL2ZIPPER_HPP
 #include "types.hpp"
 #include <zipper/expression/nullary/StlMDArray.hpp>
 
@@ -13,3 +14,4 @@ auto stl2zipper(auto const &M) {
 }
 
 }// namespace balsa::zipper
+#endif

--- a/geometry/include/balsa/geometry/point_cloud/bridson_poisson_disk_sampling.hpp
+++ b/geometry/include/balsa/geometry/point_cloud/bridson_poisson_disk_sampling.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#if !defined(BALSA_GEOMETRY_POINT_CLOUD_BRIDSON_POISSON_DISK_SAMPLING_HPP)
+#define BALSA_GEOMETRY_POINT_CLOUD_BRIDSON_POISSON_DISK_SAMPLING_HPP
 // Bridson's Poisson Disk Sampling
 //
 // NOTE: This file is a legacy stub from the mtao:: codebase. It depends on
@@ -25,3 +26,4 @@ namespace balsa::geometry::point_cloud {
 // Requires: balsa::geometry::grid infrastructure (not yet ported)
 
 }// namespace balsa::geometry::point_cloud
+#endif

--- a/geometry/include/balsa/geometry/point_cloud/vdb_particle_list.hpp
+++ b/geometry/include/balsa/geometry/point_cloud/vdb_particle_list.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#if !defined(BALSA_GEOMETRY_POINT_CLOUD_VDB_PARTICLE_LIST_HPP)
+#define BALSA_GEOMETRY_POINT_CLOUD_VDB_PARTICLE_LIST_HPP
 #include "balsa/zipper/types.hpp"
 #include <openvdb/Types.h>
 
@@ -56,3 +57,4 @@ struct VDBParticleList_PosRadVec : public VDBParticleList_PosRad {
 };
 
 }// namespace balsa::geometry::point_cloud
+#endif

--- a/geometry/include/balsa/geometry/point_cloud/vdb_points.hpp
+++ b/geometry/include/balsa/geometry/point_cloud/vdb_points.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#if !defined(BALSA_GEOMETRY_POINT_CLOUD_VDB_POINTS_HPP)
+#define BALSA_GEOMETRY_POINT_CLOUD_VDB_POINTS_HPP
 // Lightweight zipper <-> OpenVDB PointDataGrid conversion utilities.
 //
 // Read/write particle attributes (positions, velocities, radii, etc.)
@@ -301,3 +302,4 @@ inline std::vector<std::pair<std::string, std::string>> list_vdb_grids(
 }
 
 }// namespace balsa::geometry::point_cloud::vdb
+#endif

--- a/geometry/include/balsa/geometry/polygon_mesh/triangulate_polygons.hpp
+++ b/geometry/include/balsa/geometry/polygon_mesh/triangulate_polygons.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#if !defined(BALSA_GEOMETRY_POLYGON_MESH_TRIANGULATE_POLYGONS_HPP)
+#define BALSA_GEOMETRY_POLYGON_MESH_TRIANGULATE_POLYGONS_HPP
 #include "balsa/geometry/polygon_mesh/PolygonMesh.hpp"
 #include "balsa/geometry/triangle_mesh/earclipping.hpp"
 
@@ -75,3 +76,4 @@ ColVectors<index_type, 3> triangulate_polygons(const polygon_mesh::PolygonMesh<S
     }
 }
 }// namespace balsa::geometry::polygon_mesh
+#endif

--- a/geometry/tests/circumcenter_utils.hpp
+++ b/geometry/tests/circumcenter_utils.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#if !defined(BALSA_GEOMETRY_TESTS_CIRCUMCENTER_UTILS_HPP)
+#define BALSA_GEOMETRY_TESTS_CIRCUMCENTER_UTILS_HPP
 #include <zipper/concepts/Matrix.hpp>
 #include <balsa/geometry/simplex/circumcenter.hpp>
 #include <catch2/catch_approx.hpp>
@@ -16,3 +17,4 @@ void check_circumcenter_squared(::zipper::concepts::Matrix auto const &V, const 
     }
 }
 }// namespace
+#endif


### PR DESCRIPTION
## Summary
- Convert 8 remaining headers from `#pragma once` to `#if !defined(GUARD)` / `#define GUARD` / `#endif` style
- Guard names follow `BALSA_PATH_COMPONENTS_HPP` convention, derived from the header path relative to each sub-library include root (core, geometry, visualization)
- Note: build has a pre-existing fmt subproject compatibility issue with GCC 15 unrelated to this change