### PR TITLE
fix: remove eltopo/igl/pngpp from conanfile.py to match meson_options

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -29,12 +29,9 @@ __OPTIONAL_FLAGS_WITH_DEPS__ = [
     ("alembic",  [True, False], False, ["alembic/1.8.6"]),
     ("embree",   [True, False], False, ["embree3/3.13.5"]),
     ("perfetto", [True, False], False, ["perfetto/50.1"]),
-    ("pngpp",    [True, False], False, ["pngpp/0.2.10"]),
     # Options with no Conan deps (handled entirely by Meson)
     ("json",   [True, False], True,  []),
     ("partio", [True, False], False, []),  # cmake subproject; disabled in CI
-    ("igl",    [True, False], False, []),  # cmake subproject; disabled in CI
-    ("eltopo", [True, False], False, []),  # cmake subproject; disabled in CI
 ]
 
 __OPTIONS__ = {name: values for name, values, default, deps in __OPTIONAL_FLAGS_WITH_DEPS__}


### PR DESCRIPTION
## Summary

- PR #6 (`refactor/meson-modernize`) removed `eltopo`, `igl`, and `pngpp` from `meson_options.txt`, but `conanfile.py` still listed them in `__OPTIONAL_FLAGS_WITH_DEPS__`
- The `generate()` method pushes all entries as meson project options, causing `ERROR: Unknown options: "eltopo, igl, pngpp"` on every Conan CI run (both Linux and Windows)
- This removes the three stale entries from `conanfile.py`